### PR TITLE
fix visual studio warning about comments

### DIFF
--- a/PAYNLSDK/API/Banktransfer/Add/Request.cs
+++ b/PAYNLSDK/API/Banktransfer/Add/Request.cs
@@ -42,6 +42,7 @@ namespace PAYNLSDK.API.Banktransfer.Add
         /// </summary>
         public string Description { get; set; }
 
+        ///<summary>
         /// The id of a promotor / affiliate.
         /// In general, you won't use this unless you know the ID's of your affiliate's
         /// </summary>

--- a/PAYNLSDK/API/Refund/Add/Request.cs
+++ b/PAYNLSDK/API/Refund/Add/Request.cs
@@ -18,13 +18,13 @@ namespace PAYNLSDK.API.Refund.Add
         /// <param name="amount"></param>
         /// <param name="bankAccountHolder"></param>
         /// <param name="bankAccountNumber"></param>
-        public Request(int amount, string bankAccountHolder, string bankAccountNumber, string BankAccountBic)
+        /// <param name="bankAccountBic"></param>
+        public Request(int amount, string bankAccountHolder, string bankAccountNumber, string bankAccountBic)
         {
             this.Amount = amount;
             this.BankAccountHolder = bankAccountHolder;
             this.BankAccountNumber = bankAccountNumber;
-            this.BankAccountBic = BankAccountBic;
-
+            this.BankAccountBic = bankAccountBic;
         }
               
         /// <summary>
@@ -52,6 +52,7 @@ namespace PAYNLSDK.API.Refund.Add
         /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
         /// The id of a promotor / affiliate.
         /// In general, you won't use this unless you know the ID's of your affiliate's
         /// </summary>

--- a/PAYNLSDK/Transaction.cs
+++ b/PAYNLSDK/Transaction.cs
@@ -275,7 +275,7 @@ namespace PAYNLSDK
         /// function to approve a suspicious transaction
         /// </summary>
         /// <param name="transactionId">Transaction ID</param>
-        /// <returns>Full response including the message about the approvement
+        /// <returns>Full response including the message about the approvement</returns>
         static public PAYNLSDK.API.Transaction.Approve.Response Approve(string transactionId)
         {
             TransactionApprove request = new TransactionApprove();
@@ -289,7 +289,7 @@ namespace PAYNLSDK
         /// function to decline a suspicious transaction
         /// </summary>
         /// <param name="transactionId">Transaction ID</param>
-        /// <returns>Full response including the message about the decline
+        /// <returns>Full response including the message about the decline</returns>
         static public PAYNLSDK.API.Transaction.Decline.Response Decline(string transactionId)
         {
             TransactionDecline request = new TransactionDecline();


### PR DESCRIPTION
Fix missing closing (and opening) comment tags.
Also rename a parameter to lowercase for the sake of consistency